### PR TITLE
feat: Database Replication Setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ dependencies {
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
 }
 
 repositories {
@@ -31,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
@@ -44,11 +49,16 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     //aws
     implementation platform('software.amazon.awssdk:bom:2.21.1')
     implementation 'software.amazon.awssdk:s3'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sns/whisper/domain/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/com/sns/whisper/domain/user/infrastructure/UserRepositoryImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class UserRespositoryImpl implements UserRepository {
+public class UserRepositoryImpl implements UserRepository {
 
     private final JPAUserRepository jpaUserRepository;
 

--- a/src/main/java/com/sns/whisper/global/config/database/DataSourceConfiguration.java
+++ b/src/main/java/com/sns/whisper/global/config/database/DataSourceConfiguration.java
@@ -1,0 +1,95 @@
+package com.sns.whisper.global.config.database;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableTransactionManagement
+public class DataSourceConfiguration {
+
+    private final ReplicationDataSourceProperties dataSourceProperties;
+    private final JpaProperties jpaProperties;
+
+
+    @Bean
+    public DataSource routingDataSource() {
+
+        DataSource masterDataSource = createDataSource(
+                dataSourceProperties.getDriverClassName(),
+                dataSourceProperties.getUrl(),
+                dataSourceProperties.getUsername(),
+                dataSourceProperties.getPassword()
+        );
+
+        ReplicationRoutingDataSource routingDataSource = new ReplicationRoutingDataSource();
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put(DataSourceType.MASTER.getName(), masterDataSource);
+
+        dataSourceProperties.getSlaves()
+                            .forEach((key, slave) ->
+                                    dataSourceMap.put(slave.getName(), createDataSource(
+                                            slave.getDriverClassName(), slave.getUrl(),
+                                            slave.getUsername(),
+                                            slave.getPassword())));
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+
+        return routingDataSource;
+    }
+
+    private DataSource createDataSource(String driverClassName, String url, String userName,
+            String password) {
+        return DataSourceBuilder.create()
+                                .type(HikariDataSource.class)
+                                .driverClassName(driverClassName)
+                                .url(url)
+                                .username(userName)
+                                .password(password)
+                                .build();
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+        JpaVendorAdapter jpaVendorAdapter = new HibernateJpaVendorAdapter();
+        EntityManagerFactoryBuilder entityManagerFactoryBuilder = new EntityManagerFactoryBuilder(
+                jpaVendorAdapter, jpaProperties.getProperties(), null);
+
+        return entityManagerFactoryBuilder.dataSource(lazyRoutingDataSource())
+                                          .packages("com.sns.whisper")
+                                          .build();
+    }
+
+    //     실제 쿼리 실행 시 실제 사용할 DataSource의 Connection 획득
+    @Bean
+    public DataSource lazyRoutingDataSource() {
+        return new LazyConnectionDataSourceProxy(routingDataSource());
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(
+            @Qualifier(value = "lazyRoutingDataSource") DataSource lazyRoutingDataSource) {
+        DataSourceTransactionManager transactionManager = new DataSourceTransactionManager();
+        transactionManager.setDataSource(lazyRoutingDataSource);
+        return new DataSourceTransactionManager(lazyRoutingDataSource);
+    }
+
+}

--- a/src/main/java/com/sns/whisper/global/config/database/DataSourceType.java
+++ b/src/main/java/com/sns/whisper/global/config/database/DataSourceType.java
@@ -1,0 +1,16 @@
+package com.sns.whisper.global.config.database;
+
+public enum DataSourceType {
+    MASTER("master"),
+    SLAVE("slave");
+
+    private String name;
+
+    DataSourceType(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/sns/whisper/global/config/database/ReplicationDataSourceProperties.java
+++ b/src/main/java/com/sns/whisper/global/config/database/ReplicationDataSourceProperties.java
@@ -1,0 +1,32 @@
+package com.sns.whisper.global.config.database;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "spring.datasource")
+@Getter
+@Setter
+public class ReplicationDataSourceProperties {
+
+    private String driverClassName;
+    private String username;
+    private String password;
+    private String url;
+    private final Map<String, Slave> slaves = new HashMap<>();
+
+    @Getter
+    @Setter
+    public static class Slave {
+
+        private String name;
+        private String driverClassName;
+        private String username;
+        private String password;
+        private String url;
+    }
+}

--- a/src/main/java/com/sns/whisper/global/config/database/ReplicationRoutingDataSource.java
+++ b/src/main/java/com/sns/whisper/global/config/database/ReplicationRoutingDataSource.java
@@ -1,0 +1,42 @@
+package com.sns.whisper.global.config.database;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+
+    private SlaveNames<String> slaveNames;
+
+
+    @Override
+    public void setTargetDataSources(Map<Object, Object> targetDataSources) {
+        super.setTargetDataSources(targetDataSources);
+
+        List<String> slaves = targetDataSources.keySet()
+                                               .stream()
+                                               .map(Object::toString)
+                                               .filter(string -> string.contains(
+                                                       DataSourceType.SLAVE.getName()))
+                                               .collect(toList());
+
+        this.slaveNames = new SlaveNames<>(slaves);
+    }
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+        if (isReadOnly) {
+            String slaveName = slaveNames.getNextName();
+            log.info("Slave connected: {}", slaveName);
+            return slaveName;
+        }
+        return DataSourceType.MASTER.getName();
+    }
+}

--- a/src/main/java/com/sns/whisper/global/config/database/SlaveNames.java
+++ b/src/main/java/com/sns/whisper/global/config/database/SlaveNames.java
@@ -1,0 +1,18 @@
+package com.sns.whisper.global.config.database;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SlaveNames<T> {
+
+    private final List<T> values;
+    private int counter = 0;
+
+    public T getNextName() {
+        if (counter >= values.size() - 1) {
+            counter = -1;
+        }
+        return values.get(++counter);
+    }
+}

--- a/src/test/java/com/sns/whisper/spring/config/DataSourceTest.java
+++ b/src/test/java/com/sns/whisper/spring/config/DataSourceTest.java
@@ -1,0 +1,46 @@
+package com.sns.whisper.spring.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+public class DataSourceTest {
+
+    public final String TEST_METHOD = "determineCurrentLookupKey";
+
+    @Test
+    @DisplayName("Master Data Source")
+    @Transactional
+    void masterDataSourceTest(@Qualifier("routingDataSource") DataSource routingDataSource)
+            throws Exception {
+        Method determineCurrentLookupKey = AbstractRoutingDataSource.class.getDeclaredMethod(
+                TEST_METHOD);
+        determineCurrentLookupKey.setAccessible(true);
+
+        String dataSourceType = (String) determineCurrentLookupKey.invoke(routingDataSource);
+
+        assertThat(dataSourceType).isEqualTo("master");
+    }
+
+    @Test
+    @DisplayName("Slave Data Source")
+    @Transactional(readOnly = true)
+    void slaveDataSourceTest(@Qualifier("routingDataSource") DataSource routingDataSource)
+            throws Exception {
+        Method determineCurrentLookupKey = AbstractRoutingDataSource.class.getDeclaredMethod(
+                TEST_METHOD);
+        determineCurrentLookupKey.setAccessible(true);
+
+        String dataSourceType = (String) determineCurrentLookupKey.invoke(routingDataSource);
+
+        assertThat(dataSourceType).contains("slave");
+    }
+}


### PR DESCRIPTION
## 개발 파트

- [ ] FE
- [x] BE
- [ ] Other

## 개발 기능 목록

- Spring Level에서 데이터베이스 Replication Setting 적용
- .

### 구현 상세
- AbstractRoutingDataSource를 상속하는 클래스를 작성하여 데이터베이스 접근 요청 시 동적으로 DataSource를 할당할 수 있도록 구현
- PlatformTransactionManager와 LazyConnectionDataSourceProxy 설정을 통해 커넥션을 미리 가져오지 않고, 쿼리 실행 시 가져올  수 있도록 설정

### 고민한 점 & 리뷰 포인트
