### PR TITLE
fix: 사용자 아이디로 사용자 조회 로직 수정

### DIFF
--- a/src/main/java/com/sns/whisper/domain/user/domain/profile/BasicProfile.java
+++ b/src/main/java/com/sns/whisper/domain/user/domain/profile/BasicProfile.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 @Embeddable
 public class BasicProfile {
 
-    @Column(nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false, unique = true)
     private String userId;
     @Column(nullable = false)
     private String password;

--- a/src/main/java/com/sns/whisper/domain/user/infrastructure/JPAUserRepository.java
+++ b/src/main/java/com/sns/whisper/domain/user/infrastructure/JPAUserRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JPAUserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByUserId(String userId);
+    boolean existsByBasicProfileUserId(String userId);
 }

--- a/src/test/java/com/sns/whisper/spring/user/UserRepositoryTest.java
+++ b/src/test/java/com/sns/whisper/spring/user/UserRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.sns.whisper.spring.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sns.whisper.domain.user.domain.User;
+import com.sns.whisper.domain.user.infrastructure.JPAUserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+public class UserRepositoryTest {
+
+    @Autowired
+    private JPAUserRepository userRepository;
+
+    @Test
+    @DisplayName("아이디가 이미 존재하는지 조회해온다.")
+    void isDuplicatedUserId_Success() throws Exception {
+        //given
+        String userId = "userId";
+        String password = "password1234";
+        LocalDate birth = LocalDate.of(1999, 11, 30);
+        String profileImage = "http://testImages.test/test.jpg";
+        String profileMessage = "프로필 메세지";
+        String email = "test@gmail.com";
+
+        User user = User.create(userId, password, email, birth, profileImage, profileMessage,
+                LocalDateTime.now());
+
+        userRepository.save(user);
+
+        //when
+        boolean result = userRepository.existsByBasicProfileUserId(userId);
+
+        //then
+        assertThat(result).isTrue();
+    }
+}


### PR DESCRIPTION
## 개발 파트

- [ ] FE
- [X] BE
- [ ] Other

## 개발 기능 목록
- 사용자 아이디로 사용자 조회 로직 수정

### 구현 상세
- 사용자 아이디로 사용자를 조회하는 쿼리 에러 발견 후 수정 완료, 테스트를 추가하여 동작 확인
- 사용자 아이디 userId에 unique 제약조건을 추가 

### 고민한 점 & 리뷰 포인트
- 동시에 같은 아이디로 회원가입을 할 때 발생할 수 있는 동시성 문제를 해결하기 위해 사용자 아이디에 unique 제약 조건을 추가함