### PR TITLE
refactor: 로그인 서비스 모듈 분리

### DIFF
--- a/src/main/java/com/sns/whisper/domain/user/application/LoginService.java
+++ b/src/main/java/com/sns/whisper/domain/user/application/LoginService.java
@@ -1,0 +1,7 @@
+package com.sns.whisper.domain.user.application;
+
+public interface LoginService {
+
+    void login(String userId, String password);
+
+}

--- a/src/main/java/com/sns/whisper/domain/user/application/SessionLoginService.java
+++ b/src/main/java/com/sns/whisper/domain/user/application/SessionLoginService.java
@@ -1,0 +1,33 @@
+package com.sns.whisper.domain.user.application;
+
+import com.sns.whisper.domain.user.application.session.SessionManager;
+import com.sns.whisper.domain.user.domain.User;
+import com.sns.whisper.domain.user.domain.respository.UserRepository;
+import com.sns.whisper.exception.user.LoginFailException;
+import com.sns.whisper.global.common.PasswordEncryptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SessionLoginService implements LoginService {
+
+    private final UserRepository userRepository;
+    private final SessionManager sessionManager;
+
+    @Override
+    public void login(String userId, String password) {
+        User savedUser = userRepository.findUserByUserId(userId)
+                                       .orElseThrow(LoginFailException::new);
+
+        if (!PasswordEncryptor.isMatch(password, savedUser.getPassword())) {
+            throw new LoginFailException();
+        }
+
+        sessionManager.saveUser(userId);
+
+    }
+
+}

--- a/src/main/java/com/sns/whisper/domain/user/application/UserService.java
+++ b/src/main/java/com/sns/whisper/domain/user/application/UserService.java
@@ -8,7 +8,6 @@ import com.sns.whisper.domain.user.domain.respository.ProfileStorage;
 import com.sns.whisper.domain.user.domain.respository.UserRepository;
 import com.sns.whisper.exception.user.DuplicatedUserIdException;
 import com.sns.whisper.exception.user.FileUploadException;
-import com.sns.whisper.exception.user.LoginFailException;
 import com.sns.whisper.global.common.PasswordEncryptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -51,16 +50,4 @@ public class UserService {
                 request.getJoinedAt());
     }
 
-
-    public void login(String userId, String password) {
-        User savedUser = userRepository.findUserByUserId(userId)
-                                       .orElseThrow(LoginFailException::new);
-
-        if (!PasswordEncryptor.isMatch(password, savedUser.getPassword())) {
-            throw new LoginFailException();
-        }
-
-        sessionManager.saveUser(userId);
-
-    }
 }

--- a/src/main/java/com/sns/whisper/domain/user/application/UserService.java
+++ b/src/main/java/com/sns/whisper/domain/user/application/UserService.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class GeneralUserService {
+public class UserService {
 
     private final UserRepository userRepository;
     private final ProfileStorage profileStorage;

--- a/src/main/java/com/sns/whisper/domain/user/presentation/UserController.java
+++ b/src/main/java/com/sns/whisper/domain/user/presentation/UserController.java
@@ -1,5 +1,6 @@
 package com.sns.whisper.domain.user.presentation;
 
+import com.sns.whisper.domain.user.application.LoginService;
 import com.sns.whisper.domain.user.application.UserService;
 import com.sns.whisper.domain.user.presentation.request.UserSignUpRequest;
 import com.sns.whisper.global.dto.HttpResponseDto;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+    private final LoginService loginService;
 
     @PostMapping
     public ResponseEntity<?> signUp(@Valid UserSignUpRequest request) {
@@ -31,7 +33,7 @@ public class UserController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@NotBlank String userId, @NotBlank String password) {
-        userService.login(userId, password);
+        loginService.login(userId, password);
         return HttpResponseDto.ok(HttpStatus.OK, "로그인되었습니다.");
     }
 

--- a/src/main/java/com/sns/whisper/domain/user/presentation/UserController.java
+++ b/src/main/java/com/sns/whisper/domain/user/presentation/UserController.java
@@ -1,6 +1,6 @@
 package com.sns.whisper.domain.user.presentation;
 
-import com.sns.whisper.domain.user.application.GeneralUserService;
+import com.sns.whisper.domain.user.application.UserService;
 import com.sns.whisper.domain.user.presentation.request.UserSignUpRequest;
 import com.sns.whisper.global.dto.HttpResponseDto;
 import jakarta.validation.Valid;
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/users")
 public class UserController {
 
-    private final GeneralUserService userService;
+    private final UserService userService;
 
     @PostMapping
     public ResponseEntity<?> signUp(@Valid UserSignUpRequest request) {

--- a/src/test/java/com/sns/whisper/spring/integration/user/LoginServiceIntegrationTest.java
+++ b/src/test/java/com/sns/whisper/spring/integration/user/LoginServiceIntegrationTest.java
@@ -1,0 +1,93 @@
+package com.sns.whisper.spring.integration.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.sns.whisper.common.factory.UserFactory;
+import com.sns.whisper.domain.user.application.LoginService;
+import com.sns.whisper.domain.user.application.session.SessionManager;
+import com.sns.whisper.domain.user.domain.User;
+import com.sns.whisper.domain.user.infrastructure.JPAUserRepository;
+import com.sns.whisper.exception.user.LoginFailException;
+import com.sns.whisper.global.common.PasswordEncryptor;
+import com.sns.whisper.spring.integration.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+public class LoginServiceIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private LoginService loginService;
+
+    @Autowired
+    private JPAUserRepository userRepository;
+
+    @Autowired
+    private SessionManager sessionManager;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+    }
+
+
+    @Test
+    @DisplayName("가입 회원의 유효한 회원 아이디와 비밀번호를 입력하면, 로그인할 수 있다.")
+    void login_ValidUser_Success() throws Exception {
+        //given
+        String userId = "userId12";
+        String password = "password1234";
+
+        User user = UserFactory.createBasicUser(userId, password);
+        userRepository.save(user);
+
+        //when
+        loginService.login(userId, password);
+
+        //then
+        assertThat(sessionManager.extractUser("ACCESS_USER")).isEqualTo(userId);
+        assertThat(PasswordEncryptor.isMatch(password, user.getPassword())).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("가입하지 않은 회원은 로그인을 할 수 없다.")
+    void login_NotValidUserId_ExceptionThrown() throws Exception {
+        //given
+        String userId = "userId123";
+        String password = "password1234";
+
+        //when, then
+        assertThatCode(() -> loginService.login(userId, password))
+                .isInstanceOf(
+                        LoginFailException.class)
+                .hasFieldOrPropertyWithValue(
+                        "httpStatus",
+                        HttpStatus.BAD_REQUEST)
+                .hasMessage("아이디와 비밀번호를 확인해주세요.");
+
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 비밀번호를 입력할 경우 로그인을 할 수 없다.")
+    void login_NotValidPassword_ExceptionThrown() throws Exception {
+        //given
+        String userId = "userId123";
+        String wrongPassword = "wrongPass1234";
+
+        User user = UserFactory.createBasicUser(userId, "password1234");
+        userRepository.save(user);
+
+        //when, then
+        assertThatCode(() -> loginService.login(userId, wrongPassword))
+                .isInstanceOf(
+                        LoginFailException.class)
+                .hasFieldOrPropertyWithValue(
+                        "httpStatus",
+                        HttpStatus.BAD_REQUEST)
+                .hasMessage("아이디와 비밀번호를 확인해주세요.");
+    }
+}

--- a/src/test/java/com/sns/whisper/spring/integration/user/UserServiceIntegrationTest.java
+++ b/src/test/java/com/sns/whisper/spring/integration/user/UserServiceIntegrationTest.java
@@ -4,21 +4,19 @@ package com.sns.whisper.spring.integration.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import com.sns.whisper.common.factory.UserFactory;
 import com.sns.whisper.domain.user.application.UserService;
 import com.sns.whisper.domain.user.application.dto.request.UserSignUpServiceRequest;
 import com.sns.whisper.domain.user.application.dto.response.UserResponse;
-import com.sns.whisper.domain.user.application.session.SessionManager;
 import com.sns.whisper.domain.user.domain.User;
 import com.sns.whisper.domain.user.domain.profile.UserStatus;
 import com.sns.whisper.domain.user.infrastructure.JPAUserRepository;
 import com.sns.whisper.exception.user.DuplicatedUserIdException;
-import com.sns.whisper.exception.user.LoginFailException;
-import com.sns.whisper.global.common.PasswordEncryptor;
 import com.sns.whisper.spring.integration.IntegrationTest;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +32,15 @@ public class UserServiceIntegrationTest extends IntegrationTest {
     private JPAUserRepository userRepository;
 
     @Autowired
-    private SessionManager sessionManager;
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        entityManager
+                .createNativeQuery(
+                        "ALTER TABLE \"user\" ALTER COLUMN `id` RESTART WITH 1")
+                .executeUpdate();
+    }
 
     @AfterEach
     void tearDown() {
@@ -93,63 +99,6 @@ public class UserServiceIntegrationTest extends IntegrationTest {
                                                          .hasFieldOrPropertyWithValue("httpStatus",
                                                                  HttpStatus.BAD_REQUEST)
                                                          .hasMessage("중복된 아이디입니다.");
-    }
-
-    @Test
-    @DisplayName("가입 회원의 유효한 회원 아이디와 비밀번호를 입력하면, 로그인할 수 있다.")
-    void login_ValidUser_Success() throws Exception {
-        //given
-        String userId = "userId12";
-        String password = "password1234";
-
-        User user = UserFactory.createBasicUser(userId, password);
-        userRepository.save(user);
-
-        //when
-        userService.login(userId, password);
-
-        //then
-        assertThat(sessionManager.extractUser("ACCESS_USER")).isEqualTo(userId);
-        assertThat(PasswordEncryptor.isMatch(password, user.getPassword())).isTrue();
-
-    }
-
-    @Test
-    @DisplayName("가입하지 않은 회원은 로그인을 할 수 없다.")
-    void login_NotValidUserId_ExceptionThrown() throws Exception {
-        //given
-        String userId = "userId123";
-        String password = "password1234";
-
-        //when, then
-        assertThatCode(() -> userService.login(userId, password))
-                .isInstanceOf(
-                        LoginFailException.class)
-                .hasFieldOrPropertyWithValue(
-                        "httpStatus",
-                        HttpStatus.BAD_REQUEST)
-                .hasMessage("아이디와 비밀번호를 확인해주세요.");
-
-    }
-
-    @Test
-    @DisplayName("유효하지 않은 비밀번호를 입력할 경우 로그인을 할 수 없다.")
-    void login_NotValidPassword_ExceptionThrown() throws Exception {
-        //given
-        String userId = "userId123";
-        String wrongPassword = "wrongPass1234";
-
-        User user = UserFactory.createBasicUser(userId, "password1234");
-        userRepository.save(user);
-
-        //when, then
-        assertThatCode(() -> userService.login(userId, wrongPassword))
-                .isInstanceOf(
-                        LoginFailException.class)
-                .hasFieldOrPropertyWithValue(
-                        "httpStatus",
-                        HttpStatus.BAD_REQUEST)
-                .hasMessage("아이디와 비밀번호를 확인해주세요.");
     }
 
 }

--- a/src/test/java/com/sns/whisper/spring/integration/user/UserServiceIntegrationTest.java
+++ b/src/test/java/com/sns/whisper/spring/integration/user/UserServiceIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.sns.whisper.common.factory.UserFactory;
-import com.sns.whisper.domain.user.application.GeneralUserService;
+import com.sns.whisper.domain.user.application.UserService;
 import com.sns.whisper.domain.user.application.dto.request.UserSignUpServiceRequest;
 import com.sns.whisper.domain.user.application.dto.response.UserResponse;
 import com.sns.whisper.domain.user.application.session.SessionManager;
@@ -25,10 +25,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 
-public class GeneralUserServiceIntegrationTest extends IntegrationTest {
+public class UserServiceIntegrationTest extends IntegrationTest {
 
     @Autowired
-    private GeneralUserService userService;
+    private UserService userService;
 
     @Autowired
     private JPAUserRepository userRepository;

--- a/src/test/java/com/sns/whisper/unit/ControllerTest.java
+++ b/src/test/java/com/sns/whisper/unit/ControllerTest.java
@@ -1,7 +1,7 @@
 package com.sns.whisper.unit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sns.whisper.domain.user.application.GeneralUserService;
+import com.sns.whisper.domain.user.application.UserService;
 import com.sns.whisper.domain.user.presentation.UserController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -14,11 +14,11 @@ import org.springframework.test.web.servlet.MockMvc;
 public class ControllerTest {
 
     @MockBean
-    protected GeneralUserService generalUserService;
+    protected UserService userService;
 
     @Autowired
     protected MockMvc mockMvc;
-    
+
     @Autowired
     protected ObjectMapper objectMapper;
 

--- a/src/test/java/com/sns/whisper/unit/ControllerTest.java
+++ b/src/test/java/com/sns/whisper/unit/ControllerTest.java
@@ -1,6 +1,7 @@
 package com.sns.whisper.unit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sns.whisper.domain.user.application.LoginService;
 import com.sns.whisper.domain.user.application.UserService;
 import com.sns.whisper.domain.user.presentation.UserController;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,9 @@ public class ControllerTest {
 
     @MockBean
     protected UserService userService;
+
+    @MockBean
+    protected LoginService loginService;
 
     @Autowired
     protected MockMvc mockMvc;

--- a/src/test/java/com/sns/whisper/unit/user/application/LoginServiceTest.java
+++ b/src/test/java/com/sns/whisper/unit/user/application/LoginServiceTest.java
@@ -1,0 +1,106 @@
+package com.sns.whisper.unit.user.application;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sns.whisper.common.factory.UserFactory;
+import com.sns.whisper.common.mockapi.MockUserSessionManager;
+import com.sns.whisper.domain.user.application.SessionLoginService;
+import com.sns.whisper.domain.user.domain.User;
+import com.sns.whisper.domain.user.domain.respository.UserRepository;
+import com.sns.whisper.exception.user.LoginFailException;
+import com.sns.whisper.global.common.PasswordEncryptor;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+public class LoginServiceTest {
+
+    @InjectMocks
+    private SessionLoginService loginService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Spy
+    private MockUserSessionManager sessionManager;
+
+
+    @Test
+    @DisplayName("가입회원의 유효한 아이디와 비밀번호로 로그인할 수 있다.")
+    void login_ValidUser_Success() throws Exception {
+        //given
+        String userId = "userId123";
+        String password = "password1234";
+
+        User savedUser = UserFactory.createBasicUser(userId, password);
+        when(userRepository.findUserByUserId(userId)).thenReturn(Optional.of(savedUser));
+
+        //when
+        loginService.login(userId, password);
+
+        //then
+        assertThat(sessionManager.extractUser("ACCESS_USER")).isEqualTo(userId);
+        assertThat(PasswordEncryptor.isMatch(password, savedUser.getPassword())).isTrue();
+        verify(userRepository).findUserByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("가입하지 않은 회원은 로그인을 할 수 없다.")
+    void login_NotValidUserId_ExceptionThrown() throws Exception {
+        //given
+        String userId = "userId123";
+        String password = "password1234";
+
+        //when
+        assertThatCode(() -> loginService.login(userId, password))
+                .isInstanceOf(
+                        LoginFailException.class)
+                .hasFieldOrPropertyWithValue(
+                        "httpStatus",
+                        HttpStatus.BAD_REQUEST)
+                .hasMessage("아이디와 비밀번호를 확인해주세요.");
+
+        verify(userRepository, times(1)).findUserByUserId(any(String.class));
+        verify(sessionManager, never()).saveUser(any(String.class));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 비밀번호를 입력할 경우 로그인을 할 수 없다.")
+    void login_NotValidPassword_ExceptionThrown() throws Exception {
+        //given
+        String userId = "userId123";
+        String password = "password1234";
+
+        String savedPassword = "testPassword1234";
+
+        User savedUser = UserFactory.createBasicUser(userId, savedPassword);
+
+        when(userRepository.findUserByUserId(userId)).thenReturn(Optional.of(savedUser));
+
+        //when
+        assertThatCode(() -> loginService.login(userId, password))
+                .isInstanceOf(
+                        LoginFailException.class)
+                .hasFieldOrPropertyWithValue(
+                        "httpStatus",
+                        HttpStatus.BAD_REQUEST)
+                .hasMessage("아이디와 비밀번호를 확인해주세요.");
+
+        verify(userRepository, times(1)).findUserByUserId(any(String.class));
+        verify(sessionManager, never()).saveUser(any(String.class));
+    }
+}

--- a/src/test/java/com/sns/whisper/unit/user/application/UserServiceTest.java
+++ b/src/test/java/com/sns/whisper/unit/user/application/UserServiceTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.sns.whisper.common.factory.UserFactory;
 import com.sns.whisper.common.mockapi.MockUserSessionManager;
-import com.sns.whisper.domain.user.application.GeneralUserService;
+import com.sns.whisper.domain.user.application.UserService;
 import com.sns.whisper.domain.user.application.dto.request.UserSignUpServiceRequest;
 import com.sns.whisper.domain.user.application.dto.response.UserResponse;
 import com.sns.whisper.domain.user.domain.User;
@@ -39,7 +39,7 @@ import org.springframework.http.HttpStatus;
 public class UserServiceTest {
 
     @InjectMocks
-    private GeneralUserService userService;
+    private UserService userService;
 
     @Mock
     private ProfileStorage profileStorage;

--- a/src/test/java/com/sns/whisper/unit/user/application/UserServiceTest.java
+++ b/src/test/java/com/sns/whisper/unit/user/application/UserServiceTest.java
@@ -4,13 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.sns.whisper.common.factory.UserFactory;
-import com.sns.whisper.common.mockapi.MockUserSessionManager;
 import com.sns.whisper.domain.user.application.UserService;
 import com.sns.whisper.domain.user.application.dto.request.UserSignUpServiceRequest;
 import com.sns.whisper.domain.user.application.dto.response.UserResponse;
@@ -21,7 +18,6 @@ import com.sns.whisper.domain.user.domain.profile.UserStatus;
 import com.sns.whisper.domain.user.domain.respository.ProfileStorage;
 import com.sns.whisper.domain.user.domain.respository.UserRepository;
 import com.sns.whisper.exception.user.DuplicatedUserIdException;
-import com.sns.whisper.exception.user.LoginFailException;
 import com.sns.whisper.exception.user.NotValidEmailFormatException;
 import com.sns.whisper.global.common.PasswordEncryptor;
 import java.time.LocalDate;
@@ -31,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
@@ -46,9 +41,6 @@ public class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
-
-    @Spy
-    private MockUserSessionManager sessionManager;
 
 
     @DisplayName("회원가입 요청을 받으면, 승인 대기 상태의 회원을 생성한다.")
@@ -107,71 +99,6 @@ public class UserServiceTest {
                 .isInstanceOf(DuplicatedUserIdException.class)
                 .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.BAD_REQUEST)
                 .hasMessage("중복된 아이디입니다.");
-    }
-
-    @Test
-    @DisplayName("가입회원의 유효한 아이디와 비밀번호로 로그인할 수 있다.")
-    void login_ValidUser_Success() throws Exception {
-        //given
-        String userId = "userId123";
-        String password = "password1234";
-
-        User savedUser = UserFactory.createBasicUser(userId, password);
-        when(userRepository.findUserByUserId(userId)).thenReturn(Optional.of(savedUser));
-
-        //when
-        userService.login(userId, password);
-
-        //then
-        assertThat(sessionManager.extractUser("ACCESS_USER")).isEqualTo(userId);
-        assertThat(PasswordEncryptor.isMatch(password, savedUser.getPassword())).isTrue();
-        verify(userRepository).findUserByUserId(userId);
-    }
-
-    @Test
-    @DisplayName("가입하지 않은 회원은 로그인을 할 수 없다.")
-    void login_NotValidUserId_ExceptionThrown() throws Exception {
-        //given
-        String userId = "userId123";
-        String password = "password1234";
-
-        //when
-        assertThatCode(() -> userService.login(userId, password))
-                .isInstanceOf(
-                        LoginFailException.class)
-                .hasFieldOrPropertyWithValue(
-                        "httpStatus",
-                        HttpStatus.BAD_REQUEST)
-                .hasMessage("아이디와 비밀번호를 확인해주세요.");
-
-        verify(userRepository, times(1)).findUserByUserId(any(String.class));
-        verify(sessionManager, never()).saveUser(any(String.class));
-    }
-
-    @Test
-    @DisplayName("유효하지 않은 비밀번호를 입력할 경우 로그인을 할 수 없다.")
-    void login_NotValidPassword_ExceptionThrown() throws Exception {
-        //given
-        String userId = "userId123";
-        String password = "password1234";
-
-        String savedPassword = "testPassword1234";
-
-        User savedUser = UserFactory.createBasicUser(userId, savedPassword);
-
-        when(userRepository.findUserByUserId(userId)).thenReturn(Optional.of(savedUser));
-
-        //when
-        assertThatCode(() -> userService.login(userId, password))
-                .isInstanceOf(
-                        LoginFailException.class)
-                .hasFieldOrPropertyWithValue(
-                        "httpStatus",
-                        HttpStatus.BAD_REQUEST)
-                .hasMessage("아이디와 비밀번호를 확인해주세요.");
-
-        verify(userRepository, times(1)).findUserByUserId(any(String.class));
-        verify(sessionManager, never()).saveUser(any(String.class));
     }
 
     private UserSignUpServiceRequest createSignUpRequest(String email) {

--- a/src/test/java/com/sns/whisper/unit/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/sns/whisper/unit/user/presentation/UserControllerTest.java
@@ -42,7 +42,7 @@ public class UserControllerTest extends ControllerTest {
                .andExpect(status().isCreated())
                .andExpect(jsonPath("$.message").value("회원가입에 성공했습니다."));
 
-        verify(generalUserService).signUp(any(UserSignUpServiceRequest.class));
+        verify(userService).signUp(any(UserSignUpServiceRequest.class));
     }
 
     @ParameterizedTest
@@ -62,7 +62,7 @@ public class UserControllerTest extends ControllerTest {
                .andDo(print())
                .andExpect(status().isBadRequest());
 
-        verify(generalUserService, never()).signUp(any(UserSignUpServiceRequest.class));
+        verify(userService, never()).signUp(any(UserSignUpServiceRequest.class));
     }
 
     @ParameterizedTest
@@ -82,7 +82,7 @@ public class UserControllerTest extends ControllerTest {
                .andDo(print())
                .andExpect(status().isBadRequest());
 
-        verify(generalUserService, never()).signUp(any(UserSignUpServiceRequest.class));
+        verify(userService, never()).signUp(any(UserSignUpServiceRequest.class));
 
     }
 
@@ -99,7 +99,7 @@ public class UserControllerTest extends ControllerTest {
                .andDo(print())
                .andExpect(status().isOk());
 
-        verify(generalUserService).login(anyString(), anyString());
+        verify(userService).login(anyString(), anyString());
     }
 
 
@@ -117,7 +117,7 @@ public class UserControllerTest extends ControllerTest {
                .andDo(print())
                .andExpect(status().isBadRequest());
 
-        verify(generalUserService, never()).login(anyString(), anyString());
+        verify(userService, never()).login(anyString(), anyString());
     }
 
     @ParameterizedTest
@@ -134,7 +134,7 @@ public class UserControllerTest extends ControllerTest {
                .andDo(print())
                .andExpect(status().isBadRequest());
 
-        verify(generalUserService, never()).login(anyString(), anyString());
+        verify(userService, never()).login(anyString(), anyString());
     }
 
 

--- a/src/test/java/com/sns/whisper/unit/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/sns/whisper/unit/user/presentation/UserControllerTest.java
@@ -99,7 +99,7 @@ public class UserControllerTest extends ControllerTest {
                .andDo(print())
                .andExpect(status().isOk());
 
-        verify(userService).login(anyString(), anyString());
+        verify(loginService).login(anyString(), anyString());
     }
 
 
@@ -117,7 +117,7 @@ public class UserControllerTest extends ControllerTest {
                .andDo(print())
                .andExpect(status().isBadRequest());
 
-        verify(userService, never()).login(anyString(), anyString());
+        verify(loginService, never()).login(anyString(), anyString());
     }
 
     @ParameterizedTest
@@ -134,7 +134,7 @@ public class UserControllerTest extends ControllerTest {
                .andDo(print())
                .andExpect(status().isBadRequest());
 
-        verify(userService, never()).login(anyString(), anyString());
+        verify(loginService, never()).login(anyString(), anyString());
     }
 
 


### PR DESCRIPTION
## 개발 파트

- [ ] FE
- [X] BE
- [ ] Other

## 개발 기능 목록

- 로그인 서비스의 변경 가능성으로 인한 서비스 모듈 분리
- 로그인 로직 분리로 인한 테스트 코드 분리

### 구현 상세
-  세션 로그인으로 구현된 로그인이 서비스 확장에 따라 JWT Token 방식으로 변경될 가능성이 존재하여 Login Interface와 구현 클래스를 두어 로그인 로직들을 UserService에서 분리
- 로그인 관련 테스트 로직들은 LoginServiceIntegrationTest로 분리

### 고민한 점 & 리뷰 포인트
- LoginServiceIntegrationTest 테스트 로직 중 회원 ID 검증 값이 auto_increament로 인한 Assertion 에러 발생 -> setUP 메소드로 id가 1부터 시작하도록 변경
