### PR TITLE
feat: 게시물 업로드 Rollback 시 S3 저장소 이미지 삭제 구현

### DIFF
--- a/src/main/java/com/sns/whisper/domain/post/application/PostService.java
+++ b/src/main/java/com/sns/whisper/domain/post/application/PostService.java
@@ -6,9 +6,11 @@ import com.sns.whisper.domain.post.domain.repository.ImageStorage;
 import com.sns.whisper.domain.post.domain.repository.PostRepository;
 import com.sns.whisper.domain.user.domain.User;
 import com.sns.whisper.domain.user.domain.respository.UserRepository;
+import com.sns.whisper.event.post.UploadRollbackEvent;
 import com.sns.whisper.exception.post.NotFoundUserException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,9 +22,14 @@ public class PostService {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final ImageStorage imageStorage;
+    private final ApplicationEventPublisher eventPublisher;
+
 
     public Long uploadPost(PostUploadServiceRequest serviceRequest) {
         Post post = createPost(serviceRequest);
+
+        eventPublisher.publishEvent(new UploadRollbackEvent(post));
+
         return postRepository.save(post)
                              .getId();
     }

--- a/src/main/java/com/sns/whisper/domain/post/domain/Post.java
+++ b/src/main/java/com/sns/whisper/domain/post/domain/Post.java
@@ -51,6 +51,10 @@ public class Post {
         return id;
     }
 
+    public List<String> getImageUrls() {
+        return images.getImageUrls();
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/src/main/java/com/sns/whisper/domain/post/domain/repository/ImageStorage.java
+++ b/src/main/java/com/sns/whisper/domain/post/domain/repository/ImageStorage.java
@@ -6,4 +6,6 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ImageStorage {
 
     List<String> storeImages(List<MultipartFile> images, String userId);
+
+    void deleteImages(List<String> imageUrls);
 }

--- a/src/main/java/com/sns/whisper/domain/user/presentation/request/UserSignUpRequest.java
+++ b/src/main/java/com/sns/whisper/domain/user/presentation/request/UserSignUpRequest.java
@@ -53,6 +53,7 @@ public class UserSignUpRequest {
         return UserSignUpServiceRequest.builder()
                                        .userId(userId)
                                        .password(password)
+                                       .email(email)
                                        .birth(birth)
                                        .profileImage(profileImage)
                                        .profileMessage(profileMessage)

--- a/src/main/java/com/sns/whisper/event/post/UploadRollbackEvent.java
+++ b/src/main/java/com/sns/whisper/event/post/UploadRollbackEvent.java
@@ -1,0 +1,14 @@
+package com.sns.whisper.event.post;
+
+import com.sns.whisper.domain.post.domain.Post;
+import lombok.Getter;
+
+@Getter
+public class UploadRollbackEvent {
+
+    private Post post;
+
+    public UploadRollbackEvent(Post post) {
+        this.post = post;
+    }
+}

--- a/src/main/java/com/sns/whisper/event/post/UploadRollbackEventHandler.java
+++ b/src/main/java/com/sns/whisper/event/post/UploadRollbackEventHandler.java
@@ -1,0 +1,25 @@
+package com.sns.whisper.event.post;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_ROLLBACK;
+
+import com.sns.whisper.domain.post.domain.repository.ImageStorage;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UploadRollbackEventHandler {
+
+    private final ImageStorage imageStorage;
+
+    @Async
+    @TransactionalEventListener(phase = AFTER_ROLLBACK)
+    public void rollbackUploadImages(UploadRollbackEvent event) {
+        List<String> imageUrls = event.getPost()
+                                      .getImageUrls();
+        imageStorage.deleteImages(imageUrls);
+    }
+}

--- a/src/main/java/com/sns/whisper/exception/post/FileDeleteException.java
+++ b/src/main/java/com/sns/whisper/exception/post/FileDeleteException.java
@@ -1,0 +1,14 @@
+package com.sns.whisper.exception.post;
+
+import com.sns.whisper.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class FileDeleteException extends BusinessException {
+
+    private static final HttpStatus HTTP_STATUS = HttpStatus.INTERNAL_SERVER_ERROR;
+    private static final String MESSAGE = "파일 삭제에 실패했습니다.";
+
+    public FileDeleteException() {
+        super(HTTP_STATUS, MESSAGE);
+    }
+}

--- a/src/main/java/com/sns/whisper/global/config/database/DataSourceConfiguration.java
+++ b/src/main/java/com/sns/whisper/global/config/database/DataSourceConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
@@ -82,6 +83,7 @@ public class DataSourceConfiguration {
 
     //     실제 쿼리 실행 시 실제 사용할 DataSource의 Connection 획득
     @Bean
+    @Primary
     public DataSource lazyRoutingDataSource() {
         return new LazyConnectionDataSourceProxy(routingDataSource());
     }

--- a/src/test/java/com/sns/whisper/common/mockapi/MockS3ImageStorage.java
+++ b/src/test/java/com/sns/whisper/common/mockapi/MockS3ImageStorage.java
@@ -18,4 +18,9 @@ public class MockS3ImageStorage implements ImageStorage {
                      .map(image -> FileUtil.makeFileName(IMAGE_DIRECTORY, userId, image))
                      .collect(Collectors.toList());
     }
+
+    @Override
+    public void deleteImages(List<String> imageUrls) {
+        
+    }
 }


### PR DESCRIPTION
## 개발 파트

- [ ] FE
- [x] BE
- [ ] Other

## 개발 기능 목록

- 게시물 업로드 Rollback 시 S3 저장소 이미지 삭제 구현
- .

### 구현 상세
- S3 이미지 저장소에서 이미지를 삭제하는 기능 구현
- @TransactionalEventListener를 활용하여 게시물 저장 전 트랜잭션 이벤트 발행
- Rollback 발생 시, S3 저장소에 이미 저장된 이미지들을 삭제하도록 구현

### 고민한 점 & 리뷰 포인트
- S3 저장소에 이미지를 삭제하는 것은 DB 커넥션을 계속 물고 있을 필요가 없으므로 @Async 어노테이션을 활용하여 비동기적으로 수행하도록함
